### PR TITLE
API: Fix adding stdout and stderr as output files

### DIFF
--- a/include/deno/razel.ts
+++ b/include/deno/razel.ts
@@ -219,14 +219,24 @@ export class CustomCommand extends Command {
     }
 
     writeStdoutToFile(path?: string): CustomCommand {
-        this.stdout = Razel.instance().addOutputFile(path ? path : this.name);
+        const newFile = Razel.instance().addOutputFile(path ? path : this.name + ".stdout.txt");
+        if (this.stdout) {
+            assertEquals(newFile.fileName, this.stdout.fileName);
+            return this;
+        }
+        this.stdout = newFile;
         this.stdout.createdBy = this;
         this.outputs.push(this.stdout);
         return this;
     }
 
     writeStderrToFile(path?: string): CustomCommand {
-        this.stderr = Razel.instance().addOutputFile(path ? path : this.name);
+        const newFile = Razel.instance().addOutputFile(path ? path : this.name + ".stderr.txt");
+        if (this.stderr) {
+            assertEquals(newFile.fileName, this.stderr.fileName);
+            return this;
+        }
+        this.stderr = newFile;
         this.stderr.createdBy = this;
         this.outputs.push(this.stderr);
         return this;

--- a/include/python/razel.py
+++ b/include/python/razel.py
@@ -268,25 +268,21 @@ class CustomCommand(Command):
         return self
 
     def write_stdout_to_file(self, path: Optional[str] = None) -> CustomCommand:
-        new_stdout_name = path if path else self._name + ".stdout.txt"
-
+        new_file = Razel.instance().add_output_file(path if path else self._name + ".stdout.txt")
         if self._stdout:
-            assert self._stdout.file_name == new_stdout_name
+            assert new_file.file_name == self._stdout.file_name
             return self
-
-        self._stdout = Razel.instance().add_output_file(new_stdout_name)
+        self._stdout = new_file
         self._stdout._created_by = self
         self._outputs.append(self._stdout)
         return self
 
     def write_stderr_to_file(self, path: Optional[str] = None) -> CustomCommand:
-        new_stderr_name = path if path else self._name + ".stderr.txt"
-
+        new_file = Razel.instance().add_output_file(path if path else self._name + ".stderr.txt")
         if self._stderr:
-            assert self._stderr.file_name == new_stderr_name
+            assert new_file.file_name == self._stderr.file_name
             return self
-
-        self._stderr = Razel.instance().add_output_file(new_stderr_name)
+        self._stderr = new_file
         self._stderr._created_by = self
         self._outputs.append(self._stderr)
         return self

--- a/include/python/razel.py
+++ b/include/python/razel.py
@@ -268,13 +268,25 @@ class CustomCommand(Command):
         return self
 
     def write_stdout_to_file(self, path: Optional[str] = None) -> CustomCommand:
-        self._stdout = Razel.instance().add_output_file(path if path else self._name)
+        new_stdout_name = path if path else self._name + ".stdout.txt"
+
+        if self._stdout:
+            assert self._stdout.file_name == new_stdout_name
+            return self
+
+        self._stdout = Razel.instance().add_output_file(new_stdout_name)
         self._stdout._created_by = self
         self._outputs.append(self._stdout)
         return self
 
     def write_stderr_to_file(self, path: Optional[str] = None) -> CustomCommand:
-        self._stderr = Razel.instance().add_output_file(path if path else self._name)
+        new_stderr_name = path if path else self._name + ".stderr.txt"
+
+        if self._stderr:
+            assert self._stderr.file_name == new_stderr_name
+            return self
+
+        self._stderr = Razel.instance().add_output_file(new_stderr_name)
         self._stderr._created_by = self
         self._outputs.append(self._stderr)
         return self


### PR DESCRIPTION
Fixes adding stdout and stderr as output files multiple times to the same command.

Similar changes are required for TS API